### PR TITLE
chore: update CLI version in action workflow

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         echo "Installing AccuKnox ASPM scanner..."
-        pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
+        pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.8-py3-none-any.whl --break-system-packages
         echo "AccuKnox ASPM scanner installed successfully."
 
     - name: Prepare scan directory


### PR DESCRIPTION
The updated CLI now correctly enforces failure behaviour across all scan types.
This commit updates the action configuration to use the new CLI version, so workflow runs fail when any scan reports a failure.